### PR TITLE
Add if client is mining

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All metrics are exported as gauges.
 | Metric | Meaning | Labels |
 | ------ | ------- | ------ |
 | parity_up | Indicates if the Parity client is up or not | |
+| parity_mining | Indicates if the Parity client is mining or not | |
 | parity_version | The Parity client version | |
 | parity_active_peers | How many active peers does the Parity client have | |
 | parity_connected_peers | How many connected peers does the Parity client have | |

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -39,7 +39,8 @@ function createMetrics(registry: Registry, nodeURL: string): ICreateMetrics {
       'Current Block of Parity Node',
       []
     ),
-    parityUp: createGauge('parity_up', 'Parity up/down', [])
+    parityUp: createGauge('parity_up', 'Parity up/down', []),
+    ethMining: createGauge('parity_mining', 'Client actively mining new blocks', [])
   };
 
   return async () => {
@@ -47,12 +48,14 @@ function createMetrics(registry: Registry, nodeURL: string): ICreateMetrics {
       clientVersion,
       syncInfo,
       latestBlockNumber,
-      peersInfo
+      peersInfo,
+      ethMining
     ] = await Promise.all([
       makeRequest(nodeURL, 'web3_clientVersion'),
       makeRequest(nodeURL, 'eth_syncing'),
       makeRequest(nodeURL, 'eth_blockNumber'),
-      makeRequest(nodeURL, 'parity_netPeers')
+      makeRequest(nodeURL, 'parity_netPeers'),
+      makeRequest(nodeURL, 'eth_mining')
     ]);
 
     // See if call failed
@@ -62,6 +65,7 @@ function createMetrics(registry: Registry, nodeURL: string): ICreateMetrics {
     }
 
     gauges.parityUp.set(1);
+    gauges.ethMining.set(+ ethMining);
     // blocknumber
     gauges.currentBlock.set(parseInt(latestBlockNumber, 16));
     // version

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -40,7 +40,7 @@ function createMetrics(registry: Registry, nodeURL: string): ICreateMetrics {
       []
     ),
     parityUp: createGauge('parity_up', 'Parity up/down', []),
-    ethMining: createGauge('parity_mining', 'Client actively mining new blocks', [])
+    parityMining: createGauge('parity_mining', 'Client actively mining new blocks', [])
   };
 
   return async () => {
@@ -65,7 +65,7 @@ function createMetrics(registry: Registry, nodeURL: string): ICreateMetrics {
     }
 
     gauges.parityUp.set(1);
-    gauges.ethMining.set(+ ethMining);
+    gauges.parityMining.set(+ ethMining);
     // blocknumber
     gauges.currentBlock.set(parseInt(latestBlockNumber, 16));
     // version

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -40,7 +40,11 @@ function createMetrics(registry: Registry, nodeURL: string): ICreateMetrics {
       []
     ),
     parityUp: createGauge('parity_up', 'Parity up/down', []),
-    parityMining: createGauge('parity_mining', 'Client actively mining new blocks', [])
+    parityMining: createGauge(
+      'parity_mining',
+      'Client actively mining new blocks',
+      []
+    )
   };
 
   return async () => {
@@ -65,7 +69,7 @@ function createMetrics(registry: Registry, nodeURL: string): ICreateMetrics {
     }
 
     gauges.parityUp.set(1);
-    gauges.parityMining.set(+ ethMining);
+    gauges.parityMining.set(+ethMining);
     // blocknumber
     gauges.currentBlock.set(parseInt(latestBlockNumber, 16));
     // version

--- a/test/index.ts
+++ b/test/index.ts
@@ -84,6 +84,10 @@ describe('Parity Exporter with default config', () => {
     expect(parityResponse).to.contain('parity_up 1');
   });
 
+  it('parity client is mining', () => {
+    expect(parityResponse).to.contain('parity_mining 0');
+  });
+
   it('get current block', () => {
     expect(parityResponse).to.match(/parity_current_block [0-9]+/);
   });


### PR DESCRIPTION
Instead of having a complex function which costs cpu and might not be perfect, it is better to do the api call which checks if the client is mining. This can be included in the parity exporter.